### PR TITLE
Fix crash when searching for 0 patterns

### DIFF
--- a/Reloaded.Memory.Sigscan/Scanner.cs
+++ b/Reloaded.Memory.Sigscan/Scanner.cs
@@ -151,6 +151,7 @@ public unsafe partial class Scanner : IScanner, IDisposable
         var results = new PatternScanResult[patterns.Count];
         if (patterns.Count == 0)
             return results;
+        
         var completedPatternCache = new ConcurrentDictionary<string, PatternScanResult>(StringComparer.OrdinalIgnoreCase);
 
         if (loadBalance)

--- a/Reloaded.Memory.Sigscan/Scanner.cs
+++ b/Reloaded.Memory.Sigscan/Scanner.cs
@@ -123,6 +123,9 @@ public unsafe partial class Scanner : IScanner, IDisposable
     public PatternScanResult[] FindPatterns(IReadOnlyList<string> patterns, bool loadBalance = false)
     {
         var results = new PatternScanResult[patterns.Count];
+        if (patterns.Count == 0)
+            return results;
+
         if (loadBalance)
         {
             Parallel.ForEach(Partitioner.Create(patterns.ToArray(), true), (item, _, index) =>
@@ -146,6 +149,8 @@ public unsafe partial class Scanner : IScanner, IDisposable
     public PatternScanResult[] FindPatternsCached(IReadOnlyList<string> patterns, bool loadBalance = false)
     {
         var results = new PatternScanResult[patterns.Count];
+        if (patterns.Count == 0)
+            return results;
         var completedPatternCache = new ConcurrentDictionary<string, PatternScanResult>(StringComparer.OrdinalIgnoreCase);
 
         if (loadBalance)


### PR DESCRIPTION
When using the shared library but not actually giving it any patterns to scan there would be an `ArgumentOutOfRangeException` thrown in `FindPatternsCached` as it would try to create Partitioners from 0 to 0.